### PR TITLE
fix misleading proxy example for RUN OPTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ For example with a port -p external:internal - what this shows is the port mappi
 So -p 8080:80 would expose port 80 from inside the container to be accessible from the host's IP on port 8080
 http://192.168.x.x:8080 would show you what's running INSIDE the container on port 80.`
 
-
 * `-p 9117` - the port(s)
 * `-v /config` - where Jackett should store its config file.
 * `-v /downloads` - Path to torrent blackhole
+* `-e RUN_OPTS` - Optionally specify additional arguments to be passed. EG. `--ProxyConnection=10.0.0.100:1234`
 * `-e PGID` for GroupID - see below for explanation
 * `-e PUID` for UserID - see below for explanation
 * `-e TZ` for timezone EG. Europe/London

--- a/root/etc/services.d/jackett/run
+++ b/root/etc/services.d/jackett/run
@@ -1,5 +1,4 @@
 #!/usr/bin/with-contenv bash
 
 exec \
-	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe
-
+	s6-setuidgid abc mono /app/Jackett/JackettConsole.exe "${RUN_OPTS}"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

